### PR TITLE
add all table data

### DIFF
--- a/MazeRatsTables.md
+++ b/MazeRatsTables.md
@@ -1,303 +1,6 @@
-/// CHARACTER CREATION
-
-| Items |
-| - |
-| Animal Scent |
-| Bear Trap |
-| Bedroll |
-| Caltrops |
-| Chain (10 ft.) |
-| Chalk |
-| Chisel |
-| Crowbar |
-| Fishing Net |
-| Glass Marbles |
-| Glue |
-| Grappling Hook |
-| Grease |
-| Hacksaw |
-| Hammer |
-| Hand drill |
-| Horn |
-| Iron spikes |
-| Iron tongs |
-| Lantern and Oil |
-| Large Sack |
-| Lockpicks (3) |
-| Manacles |
-| Medicine |
-| Metal file |
-| Rations (3) |
-| Rope (50 ft.) |
-| Steel wire |
-| Shovel |
-| Steel mirror |
-| Ten Foot Pole |
-| Tinderbox |
-| Torch |
-| Vial of Acid |
-| Vial of Poison |
-| Waterskin |
-
-^Item
-
-
-| Appearance |
-| - |
-| Aquiline |
-| Athletic |
-| Barrel-Chested |
-| Boney |
-| Brawny |
-| Brutish |
-| Bullnecked |
-| Chiseled |
-| Coltish |
-| Corpulent |
-| Craggy |
-| Delicate |
-| Furrowed |
-| Gaunt |
-| Gorgeous |
-| Grizzled |
-| Haggard |
-| Handsome |
-| Hideous |
-| Lanky |
-| Pudgy |
-| Ripped |
-| Rosy |
-| Scrawny |
-| Sinewy |
-| Slender |
-| Slumped |
-| Solid |
-| Square-Jawed |
-| Statuesque |
-| Towering |
-| Trim |
-| Weathered |
-| Willowy |
-| Wiry |
-| Wrinkled |
-
-^Appearance
-
-
-| Physical Details |
-| - |
-| Acid scars |
-| Battle scars |
-| Birthmark |
-| Braided hair |
-| Brand mark |
-| Broken nose |
-| Bronze skinned |
-| Burn scars |
-| Bushy eyebrows |
-| Curly hair |
-| Dark skinned |
-| Dreadlocks |
-| Exotic accent |
-| Flogging scarrs |
-| Freckles |
-| Gold tooth |
-| Hoarse voice |
-| Huge beard |
-| Long hair |
-| Matted hair |
-| Missing ear |
-| Missing teeth |
-| Mustache |
-| Muttonchops |
-| Nine fingers |
-| Oiled hair |
-| One-eyed |
-| Pale skinned |
-| Piercings |
-| Ritual scars |
-| Sallow skin |
-| Shaved head |
-| Sunburned |
-| Tangled hair |
-| Tattoos |
-| Topknot |
-
-^PhysicalDetail
-
-
-| Background |
-| - |
-| Alchemist |
-| Beggar-prince |
-| Blackmailer |
-| Bounty-hunter |
-| Chimney sweep |
-| Coin-clipper |
-| Contortionist |
-| Counterfeiter |
-| Cultist |
-| Curpurse |
-| Debt-collector |
-| Deserter |
-| Fence |
-| Fortuneteller |
-| Galley slave |
-| Gambler |
-| Gravedigger |
-| Headsman |
-| Hedge knight |
-| Highwayman |
-| Housebreaker |
-| Kidnapper |
-| Mad prophet |
-| Mountebank |
-| Peddler |
-| Pit-fighter |
-| Poisoner |
-| Rat-catcher |
-| Scrivener |
-| Sellsword |
-| Slave |
-| Smuggler |
-| Street performer |
-| Tattooist |
-| Urchin |
-| Usurer |
-
-^Background
-
-
-| Clothing |
-| - |
-| Antique |
-| Battle-torn |
-| Bedraggled |
-| Blood-stained |
-| Ceremonial |
-| Dated |
-| Decaying |
-| Eccentric |
-| Elegant |
-| Embroidered |
-| Exotic |
-| Fashionable |
-| Flamboyant |
-| Food-stained |
-| Formal |
-| Frayed |
-| Frumpy |
-| Garish |
-| Grimy |
-| Haute couture |
-| Lacey |
-| Livery |
-| Mud-stained |
-| Ostentatious |
-| Oversized |
-| Patched |
-| Patterned |
-| Perfumed |
-| Practical |
-| Rumpled |
-| Sigil |
-| Singed |
-| Tasteless |
-| Undersized |
-| Wine-stained |
-| Worn out |
-
-^Clothing
-
-
-| Personality |
-| - |
-| Bitter |
-| Brave |
-| Cautious |
-| Chipper |
-| Contrary |
-| Cowardly |
-| Cunning |
-| Driven |
-| Entitled |
-| Gregarious |
-| Grumpy |
-| Heartless |
-| Honor-bound |
-| Hotheaded |
-| Inquisitive |
-| Irascible |
-| Jolly |
-| Know-it-all |
-| Lazy |
-| Loyal |
-| Menacing |
-| Mopey |
-| Nervous |
-| Protective |
-| Righteous |
-| Rude |
-| Sarcastic |
-| Savage |
-| Scheming |
-| Serene |
-| Spacey |
-| Stoic |
-| Stubborn |
-| Stuck-up |
-| Suspicious |
-| Wisecracking |
-
-^Personality
-
-
-| Mannerisms |
-| - |
-| Anecdotes |
-| Breathy |
-| Chuckles |
-| Clipped |
-| Cryptic |
-| Deep voice |
-| Drawl |
-| Enunciates |
-| Flowery speech |
-| Gravelly voice |
-| Highly formal |
-| Hypnotic |
-| Interrups |
-| Laconic |
-| Laughs |
-| Long pauses |
-| Melodious |
-| Monotone |
-| Mumbles |
-| Narrates |
-| Overly casual |
-| Quaint sayings |
-| Rambles |
-| Random facts |
-| Rapid-fire |
-| Rhyming |
-| Robotic |
-| Slow speech |
-| Speechifies |
-| Squeak |
-| Street slang |
-| Stutters |
-| Talks to self |
-| Trails off |
-| Very loud |
-| Whispers |
-
-^Mannerism
-
-
-
 /// MAGIC
 
-| Magic: Ethereal Effect |
+| Ethereal Effects |
 | - |
 | Avenging |
 | Banishing |
@@ -336,10 +39,10 @@
 | Wearying |
 | Withering |
 
-^MagicEtherealEffect
+^EtherealEffects
 
 
-| Magic: Etheral Element |
+| Etheral Elements |
 | - |
 | Ash |
 | Chaos |
@@ -378,10 +81,10 @@
 | Whisper |
 | Wind |
 
-^MagicEtherealElement
+^EtherealElements
 
 
-| Magic: Ethereal Form |
+| Ethereal Forms |
 | - |
 | Aura |
 | Beacon |
@@ -420,10 +123,10 @@
 | Wave |
 | Word |
 
-^MagicEtherealForm
+^EtherealForms
 
 
-| Magic: Physical Effect |
+| Physical Effects |
 | - |
 | Animating |
 | Attracting |
@@ -462,10 +165,10 @@
 | Transmuting |
 | Transporting |
 
-^MagicPhysicalEffect
+^PhysicalEffects
 
 
-| Magic: Physical Element |
+| Physical Elements |
 | - |
 | Acid |
 | Amber |
@@ -504,10 +207,10 @@
 | Wood |
 | Worm |
 
-^MagicPhysicalElement
+^PhysicalElements
 
 
-| Magic: Physical Form |
+| Physical Forms |
 | - |
 | Armor |
 | Arrow |
@@ -545,28 +248,28 @@
 | Wall |
 | Web |
 
-^MagicPhysicalForm
+^PhysicalForms
 
 
 | dice: 1d12 | Spells |
 | - | - |
-| 1 || `dice: [[MazeRatsTables#^MagicPhysicalEffect]]` `dice: [[MazeRatsTables#^MagicPhysicalForm]]` |
-| 2 | `dice: [[MazeRatsTables#^MagicPhysicalEffect]]` `dice: [[MazeRatsTables#^MagicEtherealForm]]` |
-| 3 | `dice: [[MazeRatsTables#^MagicEtherealEffect]]` `dice: [[MazeRatsTables#^MagicPhysicalForm]]` |
-| 4 | `dice: [[MazeRatsTables#^MagicEtherealEffect]]` `dice: [[MazeRatsTables#^MagicEtherealForm]]` |
-| 5 | `dice: [[MazeRatsTables#^MagicPhysicalElement]]` `dice: [[MazeRatsTables#^MagicPhysicalForm]]` |
-| 6 | `dice: [[MazeRatsTables#^MagicPhysicalElement]]` `dice: [[MazeRatsTables#^MagicEtherealForm]]` |
-| 7 | `dice: [[MazeRatsTables#^MagicEtherealElement]]` `dice: [[MazeRatsTables#^MagicPhysicalForm]]` |
-| 8 | `dice: [[MazeRatsTables#^MagicEtherealElement]]` `dice: [[MazeRatsTables#^MagicEtherealForm]]` |
-| 9 | `dice: [[MazeRatsTables#^MagicPhysicalEffect]]` `dice: [[MazeRatsTables#^MagicPhysicalElement]]` |
-| 10 | `dice: [[MazeRatsTables#^MagicPhysicalEffect]]` `dice: [[MazeRatsTables#^MagicEtherealElement]]` |
-| 11 | `dice: [[MazeRatsTables#^MagicEtherealEffect]]` `dice: [[MazeRatsTables#^MagicPhysicalElement]]` |
-| 12 | `dice: [[MazeRatsTables#^MagicEtherealEffect]]` `dice: [[MazeRatsTables#^MagicEtherealElement]]` |
+| 1 || `dice: [[MazeRatsTables#^PhysicalEffects]]` `dice: [[MazeRatsTables#^PhysicalForms]]` |
+| 2 | `dice: [[MazeRatsTables#^PhysicalEffects]]` `dice: [[MazeRatsTables#^EtherealForms]]` |
+| 3 | `dice: [[MazeRatsTables#^EtherealEffects]]` `dice: [[MazeRatsTables#^PhysicalForms]]` |
+| 4 | `dice: [[MazeRatsTables#^EtherealEffects]]` `dice: [[MazeRatsTables#^EtherealForms]]` |
+| 5 | `dice: [[MazeRatsTables#^PhysicalElements]]` `dice: [[MazeRatsTables#^PhysicalForms]]` |
+| 6 | `dice: [[MazeRatsTables#^PhysicalElements]]` `dice: [[MazeRatsTables#^EtherealForms]]` |
+| 7 | `dice: [[MazeRatsTables#^EtherealElements]]` `dice: [[MazeRatsTables#^PhysicalForms]]` |
+| 8 | `dice: [[MazeRatsTables#^EtherealElements]]` `dice: [[MazeRatsTables#^EtherealForms]]` |
+| 9 | `dice: [[MazeRatsTables#^PhysicalEffects]]` `dice: [[MazeRatsTables#^PhysicalElements]]` |
+| 10 | `dice: [[MazeRatsTables#^PhysicalEffects]]` `dice: [[MazeRatsTables#^EtherealElements]]` |
+| 11 | `dice: [[MazeRatsTables#^EtherealEffects]]` `dice: [[MazeRatsTables#^PhysicalElements]]` |
+| 12 | `dice: [[MazeRatsTables#^EtherealEffects]]` `dice: [[MazeRatsTables#^EtherealElements]]` |
 
 ^Spells
 
 
-|Mutations |
+| Mutations |
 | - |
 | Ages |
 | Attracts Birds |
@@ -575,11 +278,11 @@
 | Covered in hair |
 | `dice: [[MazeRatsTables#^Animal]]` arms |
 | Hunchback |
-| `dice: [[MazeRatsTables#^Item]]`-form |
+| `dice: [[MazeRatsTables#^Items]]`-form |
 | Long arms |
 | Loses all hair |
 | Loses teeth |
-| `dice: [[MazeRatsTables#^MonsterFeature]]` |
+| `dice: [[MazeRatsTables#^MonsterFeatures]]` |
 | `dice: [[MazeRatsTables#^Animal]]` eyes |
 | `dice: [[MazeRatsTables#^Animal]]` head |
 | `dice: [[MazeRatsTables#^Animal]]` legs |
@@ -589,7 +292,7 @@
 | `dice: [[MazeRatsTables#^MonsterTrait]]` |
 | No eyes |
 | No mouth |
-| `dice: [[MazeRatsTables#^MagicPhysicalElement]]`-skin |
+| `dice: [[MazeRatsTables#^PhysicalElements]]`-skin |
 | Second face |
 | Sheds skin |
 | Cyclops |
@@ -605,7 +308,7 @@
 | Translucent skin |
 | Weeps blood |
 
-^Mutation
+^Mutations
 
 
 | Insanities |
@@ -639,27 +342,27 @@
 | Hates violence |
 | Belives they are invisible |
 | Believes they are invulnerable |
-| Believes they are `dice: [[MazeRatsTables#^MonsterAbility]]` |
-| Believes they have `dice: [[MazeRatsTables#^MonsterFeature]]` |
-| Believes they are `dice: [[MazeRatsTables#^MonsterTrait]]` |
+| Believes they are `dice: [[MazeRatsTables#^MonsterAbilities]]` |
+| Believes they have `dice: [[MazeRatsTables#^MonsterFeatures]]` |
+| Believes they are `dice: [[MazeRatsTables#^MonsterTraits]]` |
 | Must sing |
-| New personality `dice: [[MazeRatsTables#^Personality]]` |
+| New personality `dice: [[MazeRatsTables#^CharacterPersonalities]]` |
 | Says thoughts |
 | Sees dead people |
 
-^Insanity
+^Insanities
 
 
 |Omens |
 | - |
 | All iron rusts |
 | Animals die |
-| Animals mutate: `dice: [[MazeRatsTables#^Mutation]]`  |
+| Animals mutate: `dice: [[MazeRatsTables#^Mutations]]`  |
 | Birds attack |
 | City appears |
 | Deadly fog |
-| Mass insanity: `dice: [[MazeRatsTables#^Insanity]]` |
-| Mass mutation: `dice: [[MazeRatsTables#^Mutation]]` |
+| Mass insanity: `dice: [[MazeRatsTables#^Insanities]]` |
+| Mass mutation: `dice: [[MazeRatsTables#^Mutations]]` |
 | Mass slumber |
 | Meteor stroke |
 | Mirrors speak |
@@ -689,12 +392,12 @@
 | Tower appears |
 | Water to blood |
 
-^Omen
+^Omens
 
 
 /// MONSTERS & ANIMALS
 
-| Aerial |
+| Aerial Animals |
 | - |
 | Albatross |
 | Bat |
@@ -733,10 +436,10 @@
 | Wasp |
 | Woodpecker |
 
-^MonsterAerial
+^AerialAnimals
 
 
-| Terrestrial |
+| Terrestrial Animals |
 | - |
 | Ant | 
 | Ape | 
@@ -775,10 +478,10 @@
 | Wolf |
 | Wolverine |
 
-^MonsterTerrestrial
+^TerrestrialAnimals
 
 
-| Aquatic |
+| Aquatic Animals |
 | - |
 | Alligator |
 | Amoeba |
@@ -817,10 +520,10 @@
 | Walrus |
 | Whale |
 
-^MonsterAquatic
+^AquaticAnimals
 
 
-| Feature |
+| Features |
 | - |
 | Antlers |
 | Beak |
@@ -859,10 +562,10 @@
 | Tusks |
 | Wings |
 
-^MonsterFeature
+^MonsterFeatures
 
 
-| Trait |
+| Traits |
 | - |
 | Amphibious |
 | Bloated |
@@ -898,13 +601,13 @@
 | Stinking |
 | Tiny |
 | Translucent |
-| `dice: [[MazeRatsTables#^MagicEtherealElement]]` |
-| `dice: [[MazeRatsTables#^MagicPhysicalElement]]` |
+| `dice: [[MazeRatsTables#^EtherealElements]]` |
+| `dice: [[MazeRatsTables#^PhysicalElements]]` |
 
-^MonsterTrait
+^MonsterTraits
 
 
-| Ability |
+| Abilities |
 | - |
 | Absorbing |
 | Acid blood |
@@ -940,10 +643,10 @@
 | Teleporting |
 | Vampiric |
 | Wall-crawling |
-| `dice: [[MazeRatsTables#^MagicEtherealEffect]]` |
-| `dice: [[MazeRatsTables#^MagicPhysicalEffect]]` |
+| `dice: [[MazeRatsTables#^EtherealEffects]]` |
+| `dice: [[MazeRatsTables#^PhysicalEffects]]` |
 
-^MonsterAbility
+^MonsterAbilities
 
 
 | Monster Tactics |
@@ -985,10 +688,10 @@
 | Toy with |
 | Use terrain |
 
-^MonsterTactic
+^MonsterTactics
 
 
-| Monster Personality |
+| Monster Personalities |
 | - |
 | Alien |
 | Aloof |
@@ -1027,10 +730,10 @@
 | Vain |
 | Xenophobic |
 
-^MonsterPersonality
+^MonsterPersonalities
 
 
-| Monster Weakness |
+| Monster Weaknesses |
 | - |
 | Bells |
 | Birdsong |
@@ -1048,14 +751,14 @@
 | Holy icon |
 | Holy water |
 | Home cooking |
-| `dice: [[MazeRatsTables#^Insanity]]` |
+| `dice: [[MazeRatsTables#^Insanities]]` |
 | Mirrors |
 | Mistletoe |
 | Moonlight |
 | Music |
 | METHODS |
 | Phylactery |
-| `dice: [[MazeRatsTables#^MagicPhysicalElement]]` |
+| `dice: [[MazeRatsTables#^PhysicalElements]]` |
 | Puzzles |
 | Riddles |
 | Rituals |
@@ -1069,13 +772,13 @@
 | Wine |
 | Wormwood |
 
-^MonsterWeakness
+^MonsterWeaknesses
 
 | dice: 1d6 | Animal |
 | - | - |
-| 1-2 | `dice: [[MazeRatsTables#^MonsterAerial]]` |
-| 3-4 | `dice: [[MazeRatsTables#^MonsterTerrestrial]]` |
-| 5-6 | `dice: [[MazeRatsTables#^MonsterAquatic]]` |
+| 1-2 | `dice: [[MazeRatsTables#^AerialAnimals]]` |
+| 3-4 | `dice: [[MazeRatsTables#^TerrestrialAnimals]]` |
+| 5-6 | `dice: [[MazeRatsTables#^AquaticAnimals]]` |
 
 ^Animal
 
@@ -1121,7 +824,7 @@
 | Taxidermist |
 | Wigmaker |
 
-^NPCCivilized
+^CivilizedNPCs
 
 
 | Underworld NPCs |
@@ -1162,7 +865,7 @@
 | Urchin |
 | Usurer |
 
-^NPCUnderworld
+^UnderworldNPCs
 
 
 | Wilderness NPCs |
@@ -1203,7 +906,7 @@
 | Witch |
 | Woodcutter |
 
-^NPCWilderness
+^WildernessNPCs
 
 
 | Female Names |
@@ -1245,7 +948,7 @@
 | Wendy |
 | Zora |
 
-^NameFemale
+^FemaleNames
 
 
 | Male Names |
@@ -1287,7 +990,7 @@
 | Waverly |
 | Webster |
 
-^NameMale
+^MaleNames
 
 
 | Surnames: Upper Class |
@@ -1329,7 +1032,7 @@
 | Wexley |
 | Wilberforce |
 
-^SurnameUpperclass
+^UpperclassSurnames
 
 
 | Surnames: Lower Class |
@@ -1371,7 +1074,26 @@
 | Tumbler |
 | Villin |
 
-^SurnameLowerclass
+^LowerclassSurnames
+
+
+| NPCs |
+| - |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^WildernessNPC]]` |
+| `dice: [[MazeRatsTables#^MaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^WildernessNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^UpperclassSurnames]]`, `dice: [[MazeRatsTables#^WildernessNPC]]` |
+| `dice: [[MazeRatsTables#^FemaleNames]]` `dice: [[MazeRatsTables#^LowerclassSurnames]]`, `dice: [[MazeRatsTables#^WildernessNPC]]` |
+
+^NPCs
+
 
 | Assets |
 | - |
@@ -1383,8 +1105,8 @@
 | Erases the evidence |
 | Excellent liar |
 | Extremely rich |
-| Faction-leader |
-| Faction-member |
+| `dice: [[MazeRatsTables#^Factions]]`-leader |
+| `dice: [[MazeRatsTables#^Factions]]`-member |
 | Feared |
 | Fortified base |
 | Gorgeous |
@@ -1412,7 +1134,7 @@
 | Spy network |
 | War hero |
 
-^NPCAssets
+^Assets
 
 
 | Liabilities |
@@ -1429,7 +1151,7 @@
 | Heretic |
 | Huge debts |
 | Imposter |
-| `dice: [[MazeRatsTables#^Insanity]]` |
+| `dice: [[MazeRatsTables#^Insanities]]` |
 | Jealous |
 | Leaves evidence |
 | Many enemies |
@@ -1454,42 +1176,42 @@
 | Weak-willed |
 | Widely despised |
 
-^NPCLiabilities
+^Liabilities
 
 
 | NPC Goals |
 | - |
 | A better life |
 | Acceptance |
-| Acquire ITEM |
-| Craft ITEM |
-| Destroy ITEM |
+| Acquire `dice: [[MazeRatsTables#^Items]]` |
+| Craft `dice: [[MazeRatsTables#^Items]]` |
+| Destroy `dice: [[MazeRatsTables#^Items]]` |
 | Enlightenment |
 | Fame |
-| Found faction |
+| Found `dice: [[MazeRatsTables#^Factions]] |
 | Freedom |
 | Glory |
-| Impress NPC |
+| Impress `dice: [[MazeRatsTables#^NPCs]]` |
 | Infamy |
-| Infiltrate faction |
+| Infiltrate `dice: [[MazeRatsTables#^Factions]]` |
 | Justice |
-| Kidnap NPC |
-| Lead faction |
+| Kidnap `dice: [[MazeRatsTables#^NPCs]]` |
+| Lead `dice: [[MazeRatsTables#^Factions]]` |
 | Learning |
-| Locate NPC |
+| Locate `dice: [[MazeRatsTables#^NPCs]]` |
 | Love |
 | Mastery |
 | Power |
 | Reach location |
-| Rescue NPC |
+| Rescue `dice: [[MazeRatsTables#^NPCs]]` |
 | Resolve dispute |
 | Restore faction |
 | Reveal a secret |
 | Revenge |
-| Sabotage faction |
+| Sabotage `dice: [[MazeRatsTables#^Factions]]` |
 | Serve a deity |
 | Serve evil |
-| Serve faction |
+| Serve `dice: [[MazeRatsTables#^Factions]]` |
 | Serve ideology |
 | Serve leader |
 | Serve the needy |
@@ -1537,7 +1259,7 @@
 | Suspected |
 | Transformed |
 
-^NPCMisfortunes
+^Misfortunes
 
 
 | Missions |
@@ -1579,7 +1301,7 @@
 | Terrorize |
 | Threaten |
 
-^NPCMissions
+^Missions
 
 
 | Methods |
@@ -1621,7 +1343,217 @@
 | Threats |
 | Violence |
 
-^NPCMethods
+^Methods
+
+
+| Appearances |
+| - |
+| Aquiline |
+| Athletic |
+| Barrel-Chested |
+| Boney |
+| Brawny |
+| Brutish |
+| Bullnecked |
+| Chiseled |
+| Coltish |
+| Corpulent |
+| Craggy |
+| Delicate |
+| Furrowed |
+| Gaunt |
+| Gorgeous |
+| Grizzled |
+| Haggard |
+| Handsome |
+| Hideous |
+| Lanky |
+| Pudgy |
+| Ripped |
+| Rosy |
+| Scrawny |
+| Sinewy |
+| Slender |
+| Slumped |
+| Solid |
+| Square-Jawed |
+| Statuesque |
+| Towering |
+| Trim |
+| Weathered |
+| Willowy |
+| Wiry |
+| Wrinkled |
+
+^Appearances
+
+
+| Physical Details |
+| - |
+| Acid scars |
+| Battle scars |
+| Birthmark |
+| Braided hair |
+| Brand mark |
+| Broken nose |
+| Bronze skinned |
+| Burn scars |
+| Bushy eyebrows |
+| Curly hair |
+| Dark skinned |
+| Dreadlocks |
+| Exotic accent |
+| Flogging scarrs |
+| Freckles |
+| Gold tooth |
+| Hoarse voice |
+| Huge beard |
+| Long hair |
+| Matted hair |
+| Missing ear |
+| Missing teeth |
+| Mustache |
+| Muttonchops |
+| Nine fingers |
+| Oiled hair |
+| One-eyed |
+| Pale skinned |
+| Piercings |
+| Ritual scars |
+| Sallow skin |
+| Shaved head |
+| Sunburned |
+| Tangled hair |
+| Tattoos |
+| Topknot |
+
+^PhysicalDetails
+
+
+| Clothing |
+| - |
+| Antique |
+| Battle-torn |
+| Bedraggled |
+| Blood-stained |
+| Ceremonial |
+| Dated |
+| Decaying |
+| Eccentric |
+| Elegant |
+| Embroidered |
+| Exotic |
+| Fashionable |
+| Flamboyant |
+| Food-stained |
+| Formal |
+| Frayed |
+| Frumpy |
+| Garish |
+| Grimy |
+| Haute couture |
+| Lacey |
+| Livery |
+| Mud-stained |
+| Ostentatious |
+| Oversized |
+| Patched |
+| Patterned |
+| Perfumed |
+| Practical |
+| Rumpled |
+| Sigil |
+| Singed |
+| Tasteless |
+| Undersized |
+| Wine-stained |
+| Worn out |
+
+^Clothing
+
+
+| Personalities |
+| - |
+| Bitter |
+| Brave |
+| Cautious |
+| Chipper |
+| Contrary |
+| Cowardly |
+| Cunning |
+| Driven |
+| Entitled |
+| Gregarious |
+| Grumpy |
+| Heartless |
+| Honor-bound |
+| Hotheaded |
+| Inquisitive |
+| Irascible |
+| Jolly |
+| Know-it-all |
+| Lazy |
+| Loyal |
+| Menacing |
+| Mopey |
+| Nervous |
+| Protective |
+| Righteous |
+| Rude |
+| Sarcastic |
+| Savage |
+| Scheming |
+| Serene |
+| Spacey |
+| Stoic |
+| Stubborn |
+| Stuck-up |
+| Suspicious |
+| Wisecracking |
+
+^Personalities
+
+
+| Mannerisms |
+| - |
+| Anecdotes |
+| Breathy |
+| Chuckles |
+| Clipped |
+| Cryptic |
+| Deep voice |
+| Drawl |
+| Enunciates |
+| Flowery speech |
+| Gravelly voice |
+| Highly formal |
+| Hypnotic |
+| Interrups |
+| Laconic |
+| Laughs |
+| Long pauses |
+| Melodious |
+| Monotone |
+| Mumbles |
+| Narrates |
+| Overly casual |
+| Quaint sayings |
+| Rambles |
+| Random facts |
+| Rapid-fire |
+| Rhyming |
+| Robotic |
+| Slow speech |
+| Speechifies |
+| Squeak |
+| Street slang |
+| Stutters |
+| Talks to self |
+| Trails off |
+| Very loud |
+| Whispers |
+
+^Mannerisms
 
 
 | Secrets |
@@ -1648,10 +1580,10 @@
 | Low born |
 | Married |
 | Mind-contolled |
-| `dice: [[MazeRatsTables#^NPCMisfortunes]]` |
+| `dice: [[MazeRatsTables#^Misfortunes]]` |
 | Monster hunter |
 | Non-human |
-| NPC |
+| `dice: [[MazeRatsTables#^NPCs]]` |
 | Polygamist |
 | Protects relic |
 | Scandalous birth |
@@ -1663,7 +1595,7 @@
 | Transformed |
 | War criminal |
 
-^NPCSecrets 
+^Secrets 
 
 
 | Reputations |
@@ -1705,7 +1637,7 @@
 | Weirdo |
 | Wise |
 
-^NPCReputations
+^Reputations
 
 
 | Hobbies |
@@ -1747,7 +1679,7 @@
 | Weaving |
 | Whiskey |
 
-^NPCHobbies
+^Hobbies
 
 
 | Relationships |
@@ -1789,7 +1721,7 @@
 | Sweetheart |
 | Unrequited love |
 
-^NPCRelationships
+^Relationships
 
 
 | Divine Domains |
@@ -1804,7 +1736,7 @@
 | Death |
 | Destiny |
 | Dreams |
-| `dice: [[MazeRatsTables#^MagicPhysicalElement]]` |
+| `dice: [[MazeRatsTables#^PhysicalElements]]` |
 | Gateways |
 | Judgement |
 | Love |
@@ -1812,7 +1744,7 @@
 | Monsters |
 | Moon |
 | Motherhood |
-| NPC |
+| `dice: [[MazeRatsTables#^NPCs]]` |
 | Oaths |
 | Order |
 | Plague |
@@ -1831,7 +1763,7 @@
 | Wealth |
 | Winter |
 
-^NPCDivineDomains
+^DivineDomains
 
 
 | After the Party |
@@ -1850,7 +1782,7 @@
 | In the stocks |
 | Inconvenient pet |
 | Insulted a noble |
-| Insulted faction |
+| Insulted `dice: [[MazeRatsTables#^Factions]]` |
 | Joined a cult |
 | Letter of thanks |
 | Lost |
@@ -1878,8 +1810,1911 @@
 
 /// TREASURE & EQUIPMENT
 
+| Miscellaneous Items |
+| - |
+| Bowl |
+| Brass bell |
+| Brooch |
+| Carved figurine |
+| Cup |
+| Deck of cards |
+| Drawing |
+| Foreign coin |
+| Game piece |
+| Glass eye |
+| Glass jar |
+| Hair comb |
+| Handkerchief |
+| Hinged box |
+| Hourglass |
+| Human tooth |
+| Hunting horn |
+| Loaded dice |
+| Long fork |
+| Numbered key |
+| Oil lamp |
+| Old doll |
+| Paint pot |
+| Pencil |
+| Purse |
+| Quill pen |
+| Salve |
+| Scissors |
+| Scroll |
+| Sealed letter |
+| Sewing needle |
+| Shaving razor |
+| Silver button |
+| Skull |
+| Tabacco pipe |
+| Wine bottle |
+
+^MiscItems
+
+
+| Worn Items |
+| - |
+| Belt |
+| Blouse |
+| Boots |
+| Bracelet |
+| Breastplate |
+| Brigandine |
+| Cincture |
+| Cloak |
+| Coat |
+| Dress |
+| Earing |
+| Eyepatch |
+| Gauntlets |
+| Glove |
+| Gown |
+| Hat |
+| Helmet |
+| Hose |
+| Leather armor |
+| Locket |
+| Mail shirt |
+| Mask |
+| Necklace |
+| Padded armor |
+| Plate mail |
+| Ring |
+| Robe |
+| Sandals |
+| Scarf |
+| Shirt |
+| Shoes |
+| Skirt |
+| Slippers |
+| Socks |
+| Trousers |
+| Veil |
+
+^WornItems
+
+
+| Weapon Items |
+| -|
+| Arming sword |
+| Backsword |
+| Battleaxe |
+| Blowpipe |
+| Claymore |
+| Club |
+| Crossbow |
+| Cutlass |
+| Dagger |
+| Flail |
+| Flanged mace |
+| Glaive |
+| Halberd |
+| Hammer |
+| Hatchet |
+| Horsebow |
+| Hunting knife |
+| Lance |
+| Longbow |
+| Longsword |
+| Mace |
+| Maul |
+| Morningstar |
+| Pike |
+| Scimitar |
+| Shortbow |
+| Sickle |
+| Sling |
+| Spear |
+| Staff |
+| Stake |
+| Stiletto |
+| Throwing axe |
+| Warhammer |
+| Warpick |
+| Whip |
+
+^WeaponItems
+
+
+| Book Subjects |
+| - |
+| Alchemy |
+| Art |
+| Astrology |
+| Blackmail |
+| Charts and maps |
+| Conspiracies |
+| Cookbook |
+| Criminals |
+| Divination |
+| Etiquette |
+| Fashion |
+| Genealogy |
+| Hagiography |
+| History |
+| Journal |
+| Language |
+| Laws |
+| Letters |
+| Lost empires |
+| Lost places |
+| Love poems |
+| Monsters |
+| Mythology |
+| Odd customs |
+| Oratory |
+| Propaganda |
+| Prophecies |
+| Siegecraft |
+| Songs |
+| State secrets |
+| Sword fighting |
+| Theology |
+| Treasures |
+| War chronicle |
+| Who's who |
+| Witch-hunting |
+
+^BookSubjects
+
+
+| Tool Items |
+| - |
+| Acid flask |
+| Bear trap |
+| Bellows |
+| Bolt-cutters |
+| Chain |
+| Chisel |
+| Crowbar |
+| Door ram |
+| Ear trumpet |
+| Fire oil |
+| Fishing hook |
+| Goggles |
+| Grapping hook |
+| Grease |
+| Hacksaw |
+| Hammer |
+| Hand drill |
+| Lantern |
+| Lens |
+| Lock and key |
+| Lockpicks |
+| Manacles |
+| Metal file |
+| Mortar and pestle |
+| Needle |
+| Pickaxe |
+| Pitchfork |
+| Pliers |
+| Pole |
+| Pulleys |
+| Rope |
+| Scissors |
+| Shovel |
+| Spikes |
+| Steel wire |
+| Tongs |
+
+^ToolItems
+
+
+| Potions |
+| - |
+| `dice: [[MazeRatsTables#^Animal]]`-form |
+| Body swap |
+| Camouflage |
+| Control animals |
+| Control `dice: [[MazeRatsTables#^PhyiscalElements]]` |
+| Cure affliction |
+| Detect evil |
+| Detect gold |
+| Detect hidden |
+| Direction sense |
+| `dice: [[MazeRatsTables#^PhyiscalElements]]`-form |
+| `dice: [[MazeRatsTables#^PhyiscalElements]]`-skin |
+| Extra arm |
+| Flight |
+| Ghost-speech |
+| Heat vision |
+| Insanity, `dice: [[MazeRatsTables#^Insanities]]` |
+| Invulnerable |
+| `dice: [[MazeRatsTables#^Items]]`-form |
+| Magic immunity |
+| Mirror image |
+| Ability, `dice: [[MazeRatsTables#^MonsterAbilities]]` |
+| Feature, `dice: [[MazeRatsTables#^MonsterFeatures]]` |
+| Trait, `dice: [[MazeRatsTables#^MonsterTraits]]` |
+| Mutation, `dice: [[MazeRatsTables#^Mutations]]` |
+| Night vision |
+| Random spell, `dice: [[MazeRatsTables#^Spells]]` |
+| Restore health |
+| Speed |
+| Stretchy |
+| Super-jump |
+| Super-strength |
+| Telekinesis |
+| Tongues |
+| Water-breathing |
+| Water-walking |
+
+^Potions
+
+
+| Magic Ingredients |
+| - |
+| Ancient liquor |
+|  `dice: [[MazeRatsTables#^Animal]]` |
+| Blind eye |
+| Boiled cat |
+| Book page, `dice: [[MazeRatsTables#^BookSubjects]]` |
+| Bottled fog |
+| Coffin nail |
+| Corpse's hair |
+| Crossroad dust |
+| Cultist entrails |
+| `dice: [[MazeRatsTables#^EdiblePlants]]` |
+| Exotic spice |
+| Killer's hand |
+| King's tooth |
+| Last breath |
+| Liar's tongue |
+| Lightning bolt |
+| Lodestone |
+| Monk's vow |
+| Monster `dice: [[MazeRatsTables#^MonsterFeatures]]` |
+| Newborn's cry |
+| Oil portrait |
+| `dice: [[MazeRatsTables#^PhyiscalElements]]` |
+| `dice: [[MazeRatsTables#^PoisonousPlants]]` |
+| Potion of `dice: [[MazeRatsTables#^Potions]]` |
+| Pyre ember |
+| Queen bee |
+| Queen's blood |
+| Ship's barnacle |
+| Star-metal |
+| Thief's finger |
+| Tomb flower |
+| `dice: [[MazeRatsTables#^ValuableMaterial]]` |
+| Wedding ring |
+| Widow's tears |
+| Wizard skull |
+
+^MagicIngredients
+
+
+| Treasure Items |
+| - |
+| Alchemy recipe |
+| Amulet |
+| Astrolabe |
+| Blueprints |
+| Calligraphy |
+| Carpet |
+| Compass |
+| Contract |
+| Crown |
+| Crystal |
+| Deed |
+| Embroidery |
+| Fine china |
+| Fine liquor |
+| Instrument |
+| Magical book |
+| Microscope |
+| Music box |
+| Orrery |
+| Painting |
+| Perfume |
+| Prayer book |
+| Printing block |
+| Rare textile |
+| Royal robes |
+| Saint's relic |
+| Scrimshaw |
+| Sextant |
+| Sheet music |
+| Signet ring |
+| Silverware |
+| Spices |
+| Spyglass |
+| Tapestry |
+| Telescope |
+| Treasure map |
+
+^TreasureItems
+
+
+| Treasure Traits |
+| - |
+| Altered |
+| Ancient |
+| Blessed |
+| Bulky |
+| Compact |
+| Consumable |
+| Cultural value |
+| Cursed |
+| Damaged |
+| Disguised |
+| Draws enemies |
+| `dice: [[MazeRatsTables#^PhysicalEffects]]` |
+| `dice: [[MazeRatsTables#^EtherealEffects]]` |
+| `dice: [[MazeRatsTables#^PhysicalElements]]` |
+| `dice: [[MazeRatsTables#^EtherealElements]]` |
+| Embellised |
+| Encoded |
+| Exotic |
+| Extra-planar |
+| Famous |
+| Forbidden |
+| Fragile |
+| Heavy |
+| Immovable |
+| Impracticable |
+| Indestructable |
+| Intelligent |
+| Masterwork |
+| Military value |
+| Non-human |
+| Owned |
+| Partial |
+| Political value |
+| Religious value |
+| Repaired |
+| Royal |
+| Toxic |
+| Vile |
+
+^TreasureTraits
+
+
+| Valuable Materials |
+| - |
+| Alabaster |
+| Amber |
+| Aquamarine |
+| Azurite |
+| Beryl |
+| Black pearl |
+| Bloodstone |
+| Bone china |
+| Chalcedony |
+| Cinnabar |
+| Coral |
+| Diamond |
+| Ebony |
+| Emerald |
+| Fire agate |
+| Garnet |
+| Gold |
+| Ivory |
+| Jade |
+| Jasper |
+| Jet |
+| Lapis lazuli |
+| Malachite |
+| Moonstone |
+| Onyx |
+| Opal |
+| Pearl |
+| Platinum |
+| Porcelain |
+| Ruby |
+| Sapphire |
+| Serpentine |
+| Silver |
+| Star iron |
+| Topaz turquoise |
+
+^ValuableMaterials
+
+
+| Items |
+| - |
+| `dice: [[MazeRatsTables#^MiscItems]]` |
+| `dice: [[MazeRatsTables#^WornItems]]` |
+| `dice: [[MazeRatsTables#^WeaponItems]]` |
+| `dice: [[MazeRatsTables#^ToolItems]]` |
+|  `dice: [[MazeRatsTables#^TreasureItems]]` |
+| Book |
+
+^Items
+
+
 /// THE CITY
+
+| City Themes |
+| - |
+|  `dice: [[MazeRatsTables#^Animal]]` |
+| Aristocracy |
+| Art |
+| Bureaucracy |
+| Castes |
+| Catacombs |
+| `dice: [[MazeRatsTables#^CityActivities]] |
+| `dice: [[MazeRatsTables#^CityEvents]]` |
+| Crime families |
+| Cruelty |
+| `dice: [[MazeRatsTables#^CityDistrictThemes]]` |
+| `dice: [[MazeRatsTables#^DivineDomains]]` |
+| `dice: [[MazeRatsTables#^Factions]] |
+| Festivals |
+| Feuds |
+| Intrigue |
+| `dice: [[MazeRatsTables#^LowerClassBuildings]]` |
+| Martial law |
+| Meritocracy |
+| [npc] |
+| Opulence |
+| `dice: [[MazeRatsTables#^PhyiscalElements]]` |
+| Pilgrimages |
+| Piracy |
+| Plutocracy |
+| Poverty |
+| Rituals |
+| Slavery |
+| Spices |
+| Theocracy |
+| Thievery |
+| Trade |
+| Tyranny |
+| `dice: [[MazeRatsTables#^UpperClassBuildings]]` |
+| Wizardry |
+| Xenophobia |
+
+^CityThemes
+
+
+| City Events |
+| - |
+| Assassination |
+| Carnival |
+| Conscription |
+| Coronation |
+| Coup |
+| Cult activity |
+| Curfew |
+| Discovery |
+| Earthquake |
+| faction war, `dice: [[MazeRatsTables#^Factions]]` vs `dice: [[MazeRatsTables#^Factions]]` |
+| Fashion trend |
+| Fire |
+| Flood |
+| Heavy fog |
+| Heavy taxes |
+| Holy day |
+| Hysteria |
+| Inquisition |
+| Insurrection |
+| Invasion |
+| Jailbreak |
+| Mass eviction |
+| Mass pardon |
+| Negotiations |
+| Plague |
+| Proclamation |
+| Prohibition |
+| Public games |
+| Refugees |
+| Rioting |
+| Roundup |
+| Scandal |
+| Serial killer |
+| Shortage |
+| Tournament |
+| Trial |
+
+^CityEvents
+
+
+| District Themes |
+| - |
+| Catacombs |
+| `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| Construction |
+| Crafts |
+| Criminality |
+| Culture |
+| Dining |
+| Education |
+| Entertainment |
+| Finance |
+| Foreigners |
+| Ghettoes |
+| Government |
+| Graveyards |
+| Green space |
+| Industrialization |
+| Judgement |
+| Livestock |
+| `dice: [[MazeRatsTables#^LowerClassBuildings]]` |
+| Marketplace |
+| Memorials |
+| Military |
+| Opulence |
+| Pollution |
+| Poverty |
+| Punishment |
+| Religion |
+| Science |
+| Trade |
+| Trash |
+| `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^UpperClassBuildings]]` |
+| Vices |
+| `dice: [[MazeRatsTables#^WildernessNPC]]` |
+| Wizardry |
+| Wonders |
+
+^DistrictThemes
+
+
+| Upper Class Buildings |
+| - |
+| Academy |
+| Alchemist |
+| Archive |
+| Art dealer |
+| Barber |
+| Bookbinder |
+| Bookseller |
+| Castle |
+| Clockmaker |
+| Clothier |
+| Courthouse |
+| Furrier |
+| Gallery |
+| Garden |
+| Haberdashery |
+| Jeweler |
+| Law office |
+| Locksmith |
+| Lounge |
+| Manor |
+| Museum |
+| Observatory |
+| Opera house |
+| Park |
+| Physician |
+| Printer |
+| Public baths |
+| Restaurant |
+| Salon |
+| Stables |
+| Taxidermist |
+| Temple |
+| Tobacconist |
+| Townhouse |
+| Winery |
+| Zoo |
+
+^UpperClassBuildings
+
+
+| Lower Class Buildings |
+| - |
+| Apothecary |
+| Asylum |
+| Baker |
+| Brewery |
+| Butcher |
+| Candlemaker |
+| Catacombs |
+| Cheesemaker |
+| Criminal den |
+| Curiousity shop |
+| Dock |
+| Fighting pit |
+| Forge |
+| Fortuneteller |
+| Gambling hall |
+| Leatherworks |
+| Marketplace |
+| Mason |
+| Mill |
+| Moneylender |
+| Orphanage |
+| Outfitter |
+| Prison |
+| Sewers |
+| Shipyards |
+| Shrine |
+| Stockyard |
+| Stonecarver |
+| Tattooist |
+| Tavern |
+| Theater |
+| Veterinarian |
+| Warehouse |
+| Watchtower |
+| Weaver |
+| Workshop |
+
+^LowerClassBuildings
+
+
+| City Activities |
+| - |
+| Abduct |
+| Beg |
+| Brawl |
+| Burgle |
+| Celebrate |
+| Chase |
+| Constuct |
+| Cook |
+| Dance |
+| Duel |
+| `dice: [[MazeRatsTables#^DungeonActivities]]` |
+| Execute |
+| Extinguish |
+| Extort |
+| Follow |
+| Gamble |
+| Haul |
+| Interrogate |
+| Marry |
+| `dice: [[MazeRatsTables#^Missions]]` |
+| Mourn |
+| Party |
+| Patrol |
+| Perform |
+| Play |
+| Preach |
+| Process |
+| Proclaim |
+| Protest |
+| Release |
+| Repair |
+| Riot |
+| Rob |
+| Search |
+| Sell |
+| `dice: [[MazeRatsTables#^WildernessActivities]]` |
+
+^CityActivities
+
+
+| Building Rooms |
+| - |
+| Arboretum |
+| Atrium |
+| Attic |
+| Aviary |
+| Ballroom |
+| Baths |
+| Bed chamber |
+| Cabinet |
+| Chapel |
+| Cloakroom |
+| Dining room |
+| Dressing room |
+| `dice: [[MazeRatsTables#^DungeonRooms]]` |
+| Garden |
+| Garret |
+| Greenhouse |
+| Junk room |
+| Kitchen |
+| Larder |
+| Library |
+| Map room |
+| Menagerie |
+| Mews |
+| Nursery |
+| Pantry |
+| Parlor |
+| Privy |
+| Root cellar |
+| Saucery |
+| Scullery |
+| Smoking room |
+| Spicery |
+| Still room |
+| Study |
+| Trophy room |
+| Wardrobe |
+
+^BuildingRooms
+
+
+| Tactical Street Features |
+| - |
+| Arcade |
+| Awnings |
+| Balconies |
+| Barricades |
+| Bridge |
+| Canal |
+| Carriages |
+| Catwalks |
+| `dice: [[MazeRatsTables#^CityActivities]]` |
+| Climbable walls |
+| Clotheslines |
+| Crowd |
+| Dead end |
+| Dense fog |
+| Downpour |
+| `dice: [[MazeRatsTables#^DungeonActivities]]` |
+| Flooding |
+| Food stalls |
+| Fountain |
+| Gates |
+| Ladders |
+| Livestock |
+| Muddy |
+| Overgrown |
+| Roof access |
+| Roof gardens |
+| Sewer access |
+| Sinkhole |
+| Slick |
+| Steep roofs |
+| Steep streets |
+| Steps |
+| Torn up street |
+| Vermin swarms |
+| Well |
+| `dice: [[MazeRatsTables#^WildernessActivities]]` |
+
+^TacticalStreetFeatures
+
+
+| Tactical Building Features |
+| - |
+| `dice: [[MazeRatsTables#^Animal]]` nests |
+| Balconies |
+| Basement access |
+| Brightly lit |
+| Broken furniture |
+| Broken glass |
+| Cabinets |
+| Carpeted floors |
+| Chandeliers |
+| Crawlspaces |
+| Drain pipes |
+| Dumbwaiters |
+| Echoing marble |
+| Hanging chains |
+| Huge fireplace |
+| Narrow ledges |
+| Open windows |
+| Ornate weapons |
+| Overgrown |
+| Patrols |
+| Piles of trash |
+| Pillars |
+| Rotting ceiling |
+| Rotting floors |
+| Rotting walls |
+| Screens |
+| Servant passages |
+| Sewer access |
+| Shadowy alcoves |
+| Skylights |
+| Spyholes |
+| Staircases |
+| Tall bookshelves |
+| Unlit |
+| Watchdogs |
+| Window drapes |
+
+^TacticalBuildingFeatures
+
+
+| Factions |
+| - |
+| Art movement |
+| Begger's guild |
+| Black market |
+| Brotherhood |
+| City guard |
+| Conspiracy |
+| Craft gulid |
+| crime family |
+| Crime ring |
+| Dark cult |
+| Explorer's club |
+| Free company |
+| Gourmand club |
+| Heist crew |
+| Heretical sect |
+| High council |
+| Hired killers |
+| Local militia |
+| National church |
+| Noble house |
+| Outlander clan |
+| Outlaw gang |
+| Political party |
+| Religious order |
+| Religious sect |
+| Resistance |
+| Royal army |
+| Royal house |
+| Scholar's circle |
+| Secret society |
+| Spy network |
+| Street artists |
+| Street gang |
+| Street musicians |
+| Theater troupe |
+| Trade company |
+
+^Factions
+
+
+| Faction Traits |
+| - |
+| Bankrupt |
+| Bureaucratic |
+| Charitable |
+| Confused |
+| Connected |
+| Corrupt |
+| Decadent |
+| Decaying |
+| Delusional |
+| Divided |
+| Dwindling |
+| Efficient |
+| Esoteric |
+| Expanding |
+| Hunted |
+| Icompetent |
+| Incorruptible |
+| Insane |
+| Insular |
+| Manipulative |
+| Martial |
+| `dice: [[MazeRatsTables#^Personalities]]` |
+| Pious |
+| Popular |
+| Righteous |
+| Ruthless |
+| Secret |
+| Subversive |
+| Supperesed |
+| Threatened |
+| Thriving |
+| Unpopular |
+| Up-and-coming |
+| Wealthy |
+| Well-prepared |
+| Xenophobic |
+
+^FactionTraits
+
+
+| Faction Goals |
+| - |
+| Advise leader |
+| Avoid detection |
+| Awaken being |
+| Collect artifacts |
+| Construct base |
+| Control faction, `dice: [[MazeRatsTables#^Factions]]` |
+| Control politics |
+| Create artifact |
+| Create monster, `dice: [[MazeRatsTables#^Animal]]` |
+| Defeat faction, `dice: [[MazeRatsTables#^Factions]]` |
+| Defend borders |
+| Defend leader |
+| Destroy artifacts |
+| Destroy being |
+| Destroy villian |
+| Enforce law |
+| Enrich members |
+| Entertain |
+| Exhange goods |
+| Hear rumors |
+| Indulge tastes |
+| Infiltrate faction, `dice: [[MazeRatsTables#^Factions]]` |
+| Map the wild |
+| Overthrow order |
+| Preserve lineage |
+| Preserve lore |
+| Produce goods |
+| Promote arts |
+| Promote craft |
+| Purge traitors |
+| Sell services |
+| Share knowledge |
+| Spread beliefs |
+| Summon evil |
+| Survive |
+| Transport goods |
+
+^FactionGoals
+
 
 /// THE WILD
 
+| Wilderness Regions |
+| - |
+| Ashy |
+| Badlands |
+| Bay |
+| Beach |
+| Delta |
+| Desert |
+| Dry lands |
+| Dune sea |
+| Dust bowl |
+| Fjords |
+| Flood lands |
+| Foothills |
+| Forest |
+| Glaciers |
+| Heath |
+| Highlands |
+| Hills |
+| Ice fields |
+| Jungle |
+| Lowlands |
+| Mesas |
+| Moor |
+| Mountains |
+| Petrified forest |
+| Plains |
+| Rainforest |
+| Riverlands |
+| Salt pan |
+| Svanna |
+| Steppe |
+| Taiga |
+| Thickets |
+| Tundra |
+| Volcanic plain |
+| Wetlands |
+| Woodlands |
+
+^WildernessRegions
+
+
+| Wilderness Landmarks |
+| - |
+| Bog |
+| Boulder field |
+| Butte |
+| Cave |
+| Cliff |
+| Crag |
+| Crater |
+| Creek |
+| Crossing |
+| Ditch |
+| Field |
+| Forest |
+| Grove |
+| Hill |
+| Hollow |
+| Hot springs |
+| Lair |
+| Lake |
+| Lakebed |
+| Marsh |
+| Mesa |
+| Moor |
+| Pass |
+| Pit |
+| Pond |
+| Rapids |
+| Ravine |
+| Ridge |
+| Rise |
+| River |
+| Rockslide |
+| Spring |
+| Swamp |
+| Thickets |
+| Valley |
+| Waterfall |
+
+^WildernessLandmarks
+
+
+| Wilderness Structures |
+| - |
+| Altar |
+| Aqueduct |
+| Bandit's camp |
+| Battlefield |
+| Bonfire |
+| Bridge |
+| Cairn |
+| Crossroads |
+| Crypt |
+| Dam |
+| Dungeon |
+| Farm |
+| Ford |
+| Fortress |
+| Gallows |
+| Graveyard |
+| Hedge |
+| Hunter's camp |
+| Inn |
+| Lumber camp |
+| Mine |
+| Monastery |
+| Monument |
+| Orchard |
+| Outpost |
+| Pasture |
+| Ruin |
+| Seclusion |
+| Shack |
+| Shrine |
+| Standing stone |
+| Temple |
+| Villag |
+| Wall |
+| Watchtower |
+| Waystone |
+
+^WildernessStructures
+
+
+| Wilderness Region Traits |
+| - |
+| Ashen |
+| Blasted |
+| Blighted |
+| Broken |
+| Consuming |
+| Corrupted |
+| Creeping |
+| Desolate |
+| `dice: [[MazeRatsTables#^DungeonRuinations]]` |
+| Eternal |
+| `dice: [[MazeRatsTables#^EtherealEffects]]` |
+| Forsaken |
+| Frozen |
+| Haunted |
+| Howling |
+| Jagged |
+| Lonely |
+| Misty |
+| Perilous |
+| Petrified |
+| Phantasmal |
+| Ravenous |
+| Savage |
+| Shadowy |
+| Shifting |
+| Shivering |
+| Sinister |
+| Sinking |
+| Smoldering |
+| Sweltering |
+| Thorny |
+| Thundering |
+| Torrential |
+| `dice: [[MazeRatsTables#^PhysicalEffects]]` |
+| Wandering |
+| Withered |
+
+^WildernessRegionTraits
+
+
+| Wilderness Discoveries |
+| - |
+| Blood stains |
+| Bones |
+| Broken weapons |
+| Burrow |
+| `dice: [[MazeRatsTables#^CityActivities]]` |
+| `dice: [[MazeRatsTables#^CivilizedNPC]]` |
+| Cut ropes |
+| Dead animal |
+| `dice: [[MazeRatsTables#^DungeonActivities]]` |
+| Food scraps |
+| Grave marker |
+| Human corpse |
+| [item] |
+| Lost [npc] |
+| Magical effect, `dice: [[MazeRatsTables#^Spell]]` |
+| Map |
+| Message |
+| Migration |
+| Mutation, `dice: [[MazeRatsTables#^Mutations]]` |
+| Nest |
+| Portal |
+| Resources |
+| Rift |
+| Strange plant |
+| Stunned [npc] |
+| Supplies |
+| Torn flag |
+| Tracks |
+| Trap |
+| Treasure cache |
+| `dice: [[MazeRatsTables#^UnderworldNPC]]` |
+| `dice: [[MazeRatsTables#^WildernessActivities]]` |
+| `dice: [[MazeRatsTables#^WildernessLandmarks]]` |
+| `dice: [[MazeRatsTables#^WildernessStructures]]` |
+| `dice: [[MazeRatsTables#^WildernessNPC]]` |
+| Wizard fight |
+
+^WildernessDiscoveries
+
+
+| Wilderness Activities |
+| - |
+| Ambush |
+| Argue |
+| Birth |
+| Build |
+| Bury |
+| Capture |
+| `dice: [[MazeRatsTables#^CityActivities]]` |
+| Convene |
+| Demolish |
+| Die |
+| Duel |
+| `dice: [[MazeRatsTables#^DungeonActivities]]` |
+| Eat |
+| Excavate |
+| Feast |
+| Felling |
+| Fish |
+| Flee |
+| Forage |
+| Hunt |
+| March |
+| Raid |
+| Rescue |
+| Rest |
+| Sacrifice |
+| Scout |
+| Sing |
+| Skin |
+| Skirmish |
+| Slay |
+| Sleep |
+| Swim |
+| Track |
+| Trap |
+| Wander |
+| Worship |
+
+^WildernessActivities
+
+
+| Widlerness Hazards |
+| - |
+| Avalanche |
+| Blizzard |
+| Brushfire |
+| Cloudburst |
+| Cyclone |
+| Dense fog |
+| Downpour |
+| Drizzle |
+| Dust storm |
+| Earthquake |
+| Eruption |
+| Flooding |
+| Forest fire |
+| Hail |
+| Heat wave |
+| Hurricane |
+| Ice storm |
+| Light mist |
+| Locust swarm |
+| Magma flow |
+| Meteor strike |
+| Monsoon |
+| Mudflow |
+| Mudslide |
+| Predator |
+| Quicksand |
+| Rain of frogs |
+| Rockslide |
+| Sandstorm |
+| Sleet |
+| Snow stampeded |
+| Thunderstorm |
+| tsunami |
+| Whirlpool |
+| Windstorm |
+
+^WildernessHazards
+
+
+| Edible Plants |
+| - |
+| Acorns |
+| Apples |
+| Asparagus |
+| Blackberries |
+| Bluebarries |
+| Carrots |
+| Cattail |
+| Cherries |
+| Chickweed |
+| Chicory |
+| Clover |
+| Dandelion |
+| Dead-nettle |
+| Elderberries |
+| Gooseberries |
+| Hazelnuts |
+| Henbit |
+| Hickory nuts |
+| Honeysuckle |
+| Leeks |
+| Milk thistle |
+| Mint |
+| Mulberries |
+| Mushrooms |
+| Mustard |
+| Onion |
+| Pecans |
+| Persimmons |
+| Raspberries |
+| Strawberries |
+| Walnuts |
+| Watercress |
+| Wild garlic |
+| Wild grapes |
+| Wood sorrel  |
+
+^EdiblePlants
+
+
+| Poisonous Plants |
+| - |
+| Angel's trumpet |
+| Baneberry |
+| Belladona |
+| Black truffle |
+| Bleeding heart |
+| Celandine |
+| Cocklebur |
+| Crowncup |
+| Death cap |
+| Dumbcane |
+| Foxglove |
+| Hemlock |
+| Hogweed |
+| Holly |
+| Horse chestnut |
+| Hyacinth |
+| Ivy |
+| Jessamine |
+| Kudu |
+| Larkspur |
+| Mandrake |
+| Mangrove |
+| Mistletoe |
+| Moonflower |
+| Nightshade |
+| Oleander |
+| Ragwort |
+| Reindeer lichen |
+| Snakeweed |
+| Spindle |
+| Stinkhorn |
+| Waxcap |
+| Wine-cap |
+| Wolfsbane |
+| Wormwood |
+
+^PoisonousPlants
+
+| Inn Names |
+| - |
+| `dice: [[MazeRatsTables#^InnAdjectives]]` `dice: [[MazeRatsTables#^InnNouns]]` |
+| `dice: [[MazeRatsTables#^InnNouns]]` `dice: [[MazeRatsTables#^InnNouns]]` |
+
+^InnNames
+
+
+| Inn Adjectives |
+| - |
+| Bellowing |
+| Blazing |
+| Bleak |
+| Blessed |
+| Bloody |
+| Crimson |
+| Cunning |
+| Copper |
+| Dancing |
+| Dead |
+| Drunken |
+| Flying |
+| Ghastly |
+| Golden |
+| Helpful |
+| Hideous |
+| Howling |
+| Hungry |
+| Modly |
+| Muttering |
+| Nimble |
+| Oozing |
+| Petrified |
+| Prancing |
+| Romantic |
+| Salty |
+| Singing |
+| Shivering |
+| Shrieking |
+| Silver |
+| Smoking |
+| Thirsty |
+| Wicked |
+| Tipsy |
+| Whistling |
+| Wanton |
+
+^InnAdjectives
+
+
+| Inn Nouns |
+| - |
+| Axe |
+| Barrel |
+| Bear |
+| Bell |
+| Boot |
+| Bowl |
+| Bucket |
+| Candle |
+| Cock |
+| Cow |
+| Dragon |
+| Egg |
+| Elephant |
+| Flea |
+| Fork |
+| Giant |
+| Griffin |
+| Hart |
+| Hog |
+| Hound |
+| Lamb |
+| Lion |
+| Mackerel |
+| Maid |
+| Monk |
+| Moon |
+| Pipe |
+| Prince |
+| Rat |
+| Skull |
+| Spoon |
+| Star |
+| Swan |
+| Sword |
+| Whale |
+| Wife |
+
+^InNouns
+
+
+| Inn Quirks |
+| - |
+| 100 years in past |
+| Always night |
+| Animal fights |
+| Bard duels |
+| Bigger inside |
+| Black market |
+| Brand new |
+| Cannibals |
+| [cityActivities] |
+| Constant party |
+| Dancing contest |
+| Dead drop |
+| [dungeonForms] |
+| Expensive |
+| Faction, `dice: [[MazeRatsTables#^Factions]]` hangout |
+| `dice: [[MazeRatsTables#^FactionTraits]]` |
+| Famous chef |
+| Fey patrons |
+| Fight club |
+| Five floors |
+| Ghost staff |
+| Haunted |
+| Hideout |
+| Inn / `dice: [[MazeRatsTables#^UpperClassBuildings]]` |
+| Inn / `dice: [[MazeRatsTables#^LowerClassBuildings]]` |
+| Magic sword |
+| Magically moves |
+| Mercs for hire |
+| Npc, [npc], hangout |
+| Preaching |
+| Secure storage |
+| Staff are kids |
+| Talking painting |
+| Underground |
+| VIP lounge |
+| Voice in well |
+| Women only |
+
+^InnQuirks
+
 /// THE MAZE
+
+| Dungeon Forms |
+| - |
+| Arena |
+| Asylum |
+| Aviary |
+| Bank |
+| Baths |
+| Body |
+| Casino |
+| Catacombs |
+| Cave |
+| Court |
+| Forge |
+| Garden |
+| Hideout |
+| Hotel |
+| `dice: [[MazeRatsTables#^LowerClassBuildings]]` |
+| Laboratory |
+| Library |
+| Market |
+| Mine |
+| Monastery |
+| Musuem |
+| Nursery |
+| Orphanage |
+| Palace |
+| Prison |
+| Sewer |
+| Ship |
+| Slave Pit |
+| Temple |
+| Theater |
+| `dice: [[MazeRatsTables#^UpperClassBuildings]]` |
+| University |
+| Vault |
+| Zoo |
+
+^DungeonForms
+
+
+| Dungeon Layout |
+| - |
+| Ant colony |
+| Central hub |
+| Claustrophobic |
+| Crisscrossing |
+| Curved |
+| Disorienting |
+| Galleria |
+| Geometric |
+| Gonzo |
+| Haphazard |
+| Highly regular |
+| Honeycomb |
+| Intertwined |
+| Isolated wings |
+| Layered |
+| Linear |
+| Loops |
+| Many corridors |
+| Mazes |
+| Mix of layouts |
+| Multiple hubs |
+| No corridors |
+| Open plan |
+| Open voids |
+| Organic |
+| Oversized |
+| Recursive |
+| Repetitive |
+| Sprawling |
+| Suspended |
+| Symbol shapes |
+| Tall and narrow |
+| Themed zones |
+| Vertical |
+| Winding |
+| Ziggurat |
+
+^DungeonLayout
+
+
+| Dungeon Ruinations |
+| - |
+| Arcane disaster |
+| Army invasion |
+| Cannibalism |
+| Civil war |
+| Collapse |
+| Crystal growth |
+| Curse |
+| Degeneration |
+| Earthquake |
+| Eruption |
+| Evil unearthed |
+| Experiments |
+| Explosion |
+| Famine |
+| Fire |
+| Flooding |
+| Fungus |
+| Haunting |
+| Ice |
+| Insanity: `dice: [[MazeRatsTables#^Insanities]]` |
+| Lava flow |
+| Magical sleep |
+| Melted |
+| Monster attack |
+| Mutation: `dice: [[MazeRatsTables#^Mutations]]` |
+| Outsider attack |
+| Overgrowth |
+| Petrification |
+| Plague |
+| Planar overlay |
+| Poison gas |
+| Resource gone |
+| Revolt |
+| Risen dead |
+| Too many traps |
+| War |
+
+^DungeonRuinations
+
+
+| Dungeon Rewards |
+| - |
+| Ancient lore |
+| Animal ally |
+| Army |
+| Blessing |
+| Blueprints |
+| Cultural artifact |
+| Enemy weakness |
+| Factoin ally |
+| Forewarning |
+| Guide |
+| Holy relic |
+| Influential ally |
+| Jewels |
+| Key |
+| Lost formula |
+| Machine |
+| Magic [item] |
+| Magical ally |
+| Map |
+| Marital ally |
+| Masterpiece |
+| Monster ally: `dice: [[MazeRatsTables#^Animal]]` |
+| Oracle |
+| Piles of loot |
+| Planar portal |
+| Prophecy |
+| Renown |
+| Spell: `dice: [[MazeRatsTables#^Spell]]` |
+| Transformation |
+| Transport |
+| `dice: [[MazeRatsTables#^TreasureItems]]` |
+| Uncovered plot |
+| `dice: [[MazeRatsTables#^ValuableMaterials]]` |
+| Vision |
+| Weapon |
+
+^DuneonRewards
+
+
+| Dungeon Activities |
+| - |
+| Besiege |
+| Capture |
+| `dice: [[MazeRatsTables#^CityActivities]]` |
+| Collect |
+| Construct |
+| Control |
+| Deliver |
+| Demolish |
+| Escape |
+| Feed |
+| Fortify |
+| Guard |
+| Hide |
+| Hunt |
+| Loot |
+| Map |
+| Mine |
+| `dice: [[MazeRatsTables#^MonsterTactics]]` |
+| Negotiate |
+| Patrol |
+| Perform ritual |
+| Purge |
+| Question |
+| Raid |
+| Repair |
+| Rescue |
+| Research |
+| Revive |
+| Riddle |
+| Scavenge |
+| Seize |
+| Tunnel |
+| Unearth |
+| Vandalize |
+| `dice: [[MazeRatsTables#^WildernessActivities]]` |
+| Worship |
+
+^DungeonActivities
+
+
+| Dungeon Rooms |
+| - |
+| Armory |
+| Banquet hall |
+| Barracks |
+| `dice: [[MazeRatsTables#^BuildingRooms]]` |
+| Catacombs |
+| Cavern |
+| Chasm |
+| Courtyard |
+| Crypt |
+| Dormitory |
+| Fighting pit |
+| Forge |
+| Fountain |
+| Gate house |
+| Guard room |
+| Kennel |
+| `dice: [[MazeRatsTables#^LowerClassBuildings]]` |
+| Laboratory |
+| Mess hall |
+| Mine shaft |
+| Museum |
+| Oubliette |
+| Pool |
+| Prison |
+| Record room |
+| Shrine |
+| Slaughterhose |
+| Stables |
+| Storeroom |
+| Throne room |
+| Torture room |
+| Treasury |
+| `dice: [[MazeRatsTables#^UpperClassBuildings]]` |
+| Vault |
+| Well |
+| Workshop |
+
+^DungeonRooms
+
+
+| Dungeon Room Details |
+| - |
+| Bas-relief |
+| Blood trail |
+| Bones |
+| Chains |
+| Chalk marks |
+| Claw marks |
+| Corpses |
+| Cracked beams |
+| Crumbling walls |
+| Decaying food |
+| Decaying nest |
+| Dripping water |
+| Fading murals |
+| Faint breeze |
+| Faint footsteps |
+| Fallen pillars |
+| Fungus |
+| Furniture |
+| Graffiti |
+| Mosaics |
+| Recent repairs |
+| Rotting books |
+| Rubble |
+| Shed skin |
+| Slime trails |
+| Spider webs |
+| Stalactites |
+| Stench |
+| Smoke stains |
+| Thick dust |
+| Torn clothes |
+| Tree roots |
+| Unusual smell |
+| Vibrations |
+| Vines |
+| Whispers |
+
+^DungeonRoomDetails
+
+
+| Dungeon Tricks |
+| - |
+| Absorption |
+| Activation |
+| Animation |
+| Blessings |
+| Communication |
+| Confusion |
+| Consumption |
+| Curses |
+| Deception |
+| Duplication |
+| `dice: [[MazeRatsTables#^EtherealEffects]]` |
+| Exchange |
+| Imprisonment |
+| Instructions |
+| Interrogation |
+| Mind-control |
+| `dice: [[MazeRatsTables#^Missons]]` |
+| Mood-alteration |
+| Nullification |
+| `dice: [[MazeRatsTables#^PhysicalEffects]]` |
+| Planeshift |
+| Protection |
+| Rejuvenation |
+| Release |
+| Reversal |
+| Rotation |
+| Scrying |
+| Size-alteration |
+| Summoning |
+| Theft |
+| Time-alteration |
+| Transformation |
+| Transmutation |
+| Transportation |
+| Wonder |
+
+^DungeonTricks
+
+
+| Dungeon Hazards |
+| - |
+| Acid drip |
+| Bloodsuckers |
+| Cave-in |
+| Choking dust |
+| Crude oil |
+| Crystal shards |
+| Deafening noise |
+| Dense fog |
+| Ensnaring vines |
+| Fallen floor |
+| Flooding |
+| Freezing |
+| Geysers |
+| Magma |
+| Magentic field |
+| Mud flow |
+| Narrow ledge |
+| Narrow passage |
+| Poison goo |
+| Precipice |
+| Quicksand |
+| Radiation |
+| Rockslide |
+| Rotten ceiling |
+| Rotten floor |
+| Sinkhole |
+| Slippery slope |
+| Spider wends |
+| Spores |
+| Steam vents |
+| Strong winds |
+| Tar pit |
+| Tight passage |
+| Toppling objects |
+| Toxic fumes |
+
+^DungeonHazards
+
+
+| Trap Effects |
+| - |
+| Acid pool |
+| Adhesive |
+| Alarm |
+| Armor melts |
+| Bear trap |
+| Blinding spray |
+| Blunt pendulum |
+| Boiling tar |
+| Collasping floor |
+| Crocodile pit |
+| Crushing walls |
+| Deep pit |
+| Falling cage |
+| Falling ceiling |
+| Fills with sand |
+| Flooding |
+| Giant magnet |
+| Hard vacuum |
+| Lava flow |
+| Lightning |
+| Living statues |
+| Missile fire |
+| Freed monster - `dice: [[MazeRatsTables#^Animal]]` |
+| Net trap |
+| Pendulm blade |
+| Poison gas |
+| Poison needle |
+| Quicksand |
+| Rage gas |
+| Rolling boulder |
+| Room freezes |
+| Room on fire |
+| Sleeping gas |
+| Spiked pit |
+| Tombs open |
+| Wall spikes |
+
+^DungeonTrapEffects
+
+
+| Trap Triggers |
+| - |
+| Blow |
+| Break |
+| Burn |
+| Choice |
+| Countdown |
+| Darkness |
+| Drain |
+| Eat |
+| Insert |
+| Kill |
+| Knock |
+| Light |
+| Magic |
+| Melody |
+| Noise |
+| Open |
+| Phrase |
+| Pour |
+| Press |
+| Proximity |
+| Pull |
+| Read |
+| Reflect |
+| Release |
+| Remove |
+| Retrieve |
+| Rudeness |
+| Shut |
+| Sit |
+| Sleep |
+| Slide |
+| Touch |
+| Turn |
+| Unbalance |
+| Unearth |
+| Write |
+
+^DungeonTrapTriggers
+
+


### PR DESCRIPTION
This should be the complete set of table data from Maze Rats. I've re-labeled most of the tables to make them easier to reference; and I've added a few non-standard tables to make item and NPC references work.